### PR TITLE
Add macro REQUIRE_SUCCESS and REQUIRE_FAILURE

### DIFF
--- a/include/kmtest/kmtest.h
+++ b/include/kmtest/kmtest.h
@@ -54,6 +54,12 @@
         ++failures; \
     }
 
+#define REQUIRE_SUCCESS(expression) \
+    REQUIRE(NT_SUCCESS(expression))
+
+#define REQUIRE_FAILURE(expression) \
+    REQUIRE(!NT_SUCCESS(expression))
+
 #pragma section("KMTEST$__a", read)
 #pragma section("KMTEST$__m", read)
 #pragma section("KMTEST$__z", read)

--- a/include/kmtest/kmtest.h
+++ b/include/kmtest/kmtest.h
@@ -54,10 +54,10 @@
         ++failures; \
     }
 
-#define REQUIRE_SUCCESS(expression) \
+#define REQUIRE_NT_SUCCESS(expression) \
     REQUIRE(NT_SUCCESS(expression))
 
-#define REQUIRE_FAILURE(expression) \
+#define REQUIRE_NT_FAILURE(expression) \
     REQUIRE(!NT_SUCCESS(expression))
 
 #pragma section("KMTEST$__a", read)


### PR DESCRIPTION
I've tired to create assertions REQUIRE(NT_SUCCESS(status)), so I decided to make a macro from it.
These macro turned out to be quite handy.