### PR TITLE
Add ability to use KMTEST_PRE_RUN_ROUTINE

### DIFF
--- a/include/kmtest/kmtest.h
+++ b/include/kmtest/kmtest.h
@@ -216,6 +216,10 @@ extern "C" inline NTSTATUS DriverEntry(_In_ DRIVER_OBJECT* driverObject, _In_ PU
     kmtest::g_driverObject = driverObject;
     kmtest::g_registryPath = *registryPath;
 
+#ifdef KMTEST_PRE_RUN_ROUTINE
+    KMTEST_PRE_RUN_ROUTINE();
+#endif
+
     kmtest::run();
 
     driverObject->DriverUnload = DriverUnload;

--- a/include/kmtest/kmtest.h
+++ b/include/kmtest/kmtest.h
@@ -168,6 +168,10 @@ namespace kmtest
         KMTEST_PRINT("* KMTEST BEGIN\n");
         KMTEST_PRINT("*******************************************************\n");
 
+        #ifdef KMTEST_PRE_RUN_ROUTINE
+            KMTEST_PRE_RUN_ROUTINE();
+        #endif
+
         int scenarios = 0;
         int assertions = 0;
         int failures = 0;
@@ -182,6 +186,10 @@ namespace kmtest
             (*testEntry)->run(assertions, failures);
             ++scenarios;
         }
+
+        #ifdef KMTEST_POST_RUN_ROUTINE
+            KMTEST_POST_RUN_ROUTINE();
+        #endif
 
         KMTEST_PRINT("*******************************************************\n");
         if (!failures)
@@ -215,10 +223,6 @@ extern "C" inline NTSTATUS DriverEntry(_In_ DRIVER_OBJECT* driverObject, _In_ PU
 {
     kmtest::g_driverObject = driverObject;
     kmtest::g_registryPath = *registryPath;
-
-#ifdef KMTEST_PRE_RUN_ROUTINE
-    KMTEST_PRE_RUN_ROUTINE();
-#endif
 
     kmtest::run();
 


### PR DESCRIPTION
You can define function KMTEST_PRE_RUN_ROUTINE without parameters to run something that is needed for driver to run once before all tests. Usually it is global preparation of environment that should be run for every test, but it is not convenient when you have dozens of them and do not want to put preparation in every scenario.
Please comment about what should I add or change.